### PR TITLE
Add Version/Since/Until to serializer to help versioning on serialization

### DIFF
--- a/src/Symfony/Component/Serializer/Annotation/Version.php
+++ b/src/Symfony/Component/Serializer/Annotation/Version.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Annotation;
+
+/**
+ * Annotation class for @Version().
+ *
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"PROPERTY", "METHOD"})
+ *
+ * @author Olivier Michaud <olivier@micoli.org>
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+final class Version
+{
+    public function __construct()
+    {
+    }
+}

--- a/src/Symfony/Component/Serializer/Annotation/VersionConstraint.php
+++ b/src/Symfony/Component/Serializer/Annotation/VersionConstraint.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Annotation;
+
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * Annotation class for @VersionConstraint().
+ *
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"PROPERTY", "METHOD"})
+ *
+ * @author Olivier Michaud <olivier@micoli.org>
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+final class VersionConstraint
+{
+    public function __construct(private readonly ?string $since = null, private readonly ?string $until = null)
+    {
+        if ('' === $since) {
+            throw new InvalidArgumentException(sprintf('Parameter since of annotation "%s" must be a non-empty string.', self::class));
+        }
+        if ('' === $until) {
+            throw new InvalidArgumentException(sprintf('Parameter since of annotation "%s" must be a non-empty string.', self::class));
+        }
+    }
+
+    public function isVersionCompatible(string $version): bool
+    {
+        if ($this->since) {
+            if (!version_compare($version, $this->since, '>=')) {
+                return false;
+            }
+        }
+        if ($this->until) {
+            if (!version_compare($version, $this->until, '<=')) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Mapping;
 
 use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -78,6 +79,27 @@ class AttributeMetadata implements AttributeMetadataInterface
      */
     public array $denormalizationContexts = [];
 
+    /**
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link isVersion()} instead.
+     */
+    public bool $version = false;
+
+    /**
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link getVersionConstraint()} instead.
+     */
+    public ?VersionConstraint $versionConstraint = null;
+
+    /**
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link isVersionCompatible()} instead.
+     */
+    public ?\Closure $versionConstraintCallable = null;
+
     public function __construct(string $name)
     {
         $this->name = $name;
@@ -142,6 +164,31 @@ class AttributeMetadata implements AttributeMetadataInterface
     public function isIgnored(): bool
     {
         return $this->ignore;
+    }
+
+    public function setVersion(bool $version): void
+    {
+        $this->version = $version;
+    }
+
+    public function isVersion(): bool
+    {
+        return $this->version;
+    }
+
+    public function setVersionConstraint(VersionConstraint $versionConstraint): void
+    {
+        $this->versionConstraint = $versionConstraint;
+    }
+
+    public function getVersionConstraint(): ?VersionConstraint
+    {
+        return $this->versionConstraint;
+    }
+
+    public function isVersionCompatible(string $version): bool
+    {
+        return !$this->versionConstraint || $this->versionConstraint->isVersionCompatible($version);
     }
 
     public function getNormalizationContexts(): array
@@ -225,6 +272,6 @@ class AttributeMetadata implements AttributeMetadataInterface
      */
     public function __sleep(): array
     {
-        return ['name', 'groups', 'maxDepth', 'serializedName', 'serializedPath', 'ignore', 'normalizationContexts', 'denormalizationContexts'];
+        return ['name', 'groups', 'maxDepth', 'serializedName', 'serializedPath', 'ignore', 'normalizationContexts', 'denormalizationContexts', 'version', 'versionConstraint'];
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Mapping;
 
 use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
 
 /**
  * Stores metadata needed for serializing and deserializing attributes.
@@ -74,6 +75,20 @@ interface AttributeMetadataInterface
      * Gets if this attribute is ignored or not.
      */
     public function isIgnored(): bool;
+
+    /**
+     * Sets if this attribute is holding the version. Only one attribute can hold version at once
+     */
+    public function setVersion(bool $version): void;
+
+    /**
+     * Gets if this attribute is holding the version.
+     */
+    public function isVersion(): bool;
+
+    public function setVersionConstraint(VersionConstraint $versionConstraint): void;
+
+    public function isVersionCompatible(string $version): bool;
 
     /**
      * Merges an {@see AttributeMetadataInterface} with in the current one.

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -19,6 +19,9 @@ use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Annotation\MaxDepth;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 use Symfony\Component\Serializer\Annotation\SerializedPath;
+use Symfony\Component\Serializer\Annotation\Version;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
+use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Exception\MappingException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
@@ -37,6 +40,8 @@ class AnnotationLoader implements LoaderInterface
         DiscriminatorMap::class,
         Groups::class,
         Ignore::class,
+        Version::class,
+        VersionConstraint::class,
         MaxDepth::class,
         SerializedName::class,
         SerializedPath::class,
@@ -65,6 +70,7 @@ class AnnotationLoader implements LoaderInterface
             }
         }
 
+        $hasVersionProperty = false;
         foreach ($reflectionClass->getProperties() as $property) {
             if (!isset($attributesMetadata[$property->name])) {
                 $attributesMetadata[$property->name] = new AttributeMetadata($property->name);
@@ -85,6 +91,14 @@ class AnnotationLoader implements LoaderInterface
                         $attributesMetadata[$property->name]->setSerializedPath($annotation->getSerializedPath());
                     } elseif ($annotation instanceof Ignore) {
                         $attributesMetadata[$property->name]->setIgnore(true);
+                    } elseif ($annotation instanceof VersionConstraint) {
+                        $attributesMetadata[$property->name]->setVersionConstraint($annotation);
+                    } elseif ($annotation instanceof Version) {
+                        if ($hasVersionProperty) {
+                            throw new LogicException(sprintf('Version on "%s::%s()" cannot be added. Version holder property can only be set once.', $className, $property->name));
+                        }
+                        $attributesMetadata[$property->name]->setVersion(true);
+                        $hasVersionProperty = true;
                     } elseif ($annotation instanceof Context) {
                         $this->setAttributeContextsForGroups($annotation, $attributesMetadata[$property->name]);
                     }
@@ -114,7 +128,7 @@ class AnnotationLoader implements LoaderInterface
                     $classMetadata->addAttributeMetadata($attributeMetadata);
                 }
             }
-
+            $hasVersionProperty = false;
             foreach ($this->loadAnnotations($method) as $annotation) {
                 if ($annotation instanceof Groups) {
                     if (!$accessorOrMutator) {
@@ -148,6 +162,23 @@ class AnnotationLoader implements LoaderInterface
                     }
 
                     $attributeMetadata->setIgnore(true);
+                } elseif ($annotation instanceof VersionConstraint) {
+                    if (!$accessorOrMutator) {
+                        throw new MappingException(sprintf('Ignore on "%s::%s()" cannot be added. Ignore can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
+                    }
+
+                    $attributeMetadata->setVersionConstraint($annotation);
+                } elseif ($annotation instanceof Version) {
+                    if (!$accessorOrMutator) {
+                        throw new MappingException(sprintf('Ignore on "%s::%s()" cannot be added. Ignore can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
+                    }
+
+                    if ($hasVersionProperty) {
+                        throw new LogicException(sprintf('Version on "%s::%s()" cannot be added. Version holder property can only be set once.', $className, $method->name));
+                    }
+
+                    $attributeMetadata->setVersion(true);
+                    $hasVersionProperty = true;
                 } elseif ($annotation instanceof Context) {
                     if (!$accessorOrMutator) {
                         throw new MappingException(sprintf('Context on "%s::%s()" cannot be added. Context can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -552,4 +552,16 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
 
         return $this->classMetadataFactory->getMetadataFor($objectOrClass)->getAttributesMetadata()[$attribute] ?? null;
     }
+
+    /**
+     * @param array<string, AttributeMetadataInterface> $attributesMetadata
+     */
+    protected function isVersionCompatible(string $version, array $attributesMetadata, string $attributeName): bool
+    {
+        if (!isset($attributesMetadata[$attributeName])) {
+            return true;
+        }
+
+        return $attributesMetadata[$attributeName]->isVersionCompatible($version);
+    }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -206,6 +206,11 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             $stack[$attribute] = $this->applyCallbacks($attributeValue, $object, $attribute, $format, $attributeContext);
         }
 
+        $objectVersion = $this->getObjectVersion($object, $stack);
+        if (null !== $objectVersion) {
+            $stack = $this->filterAttributesByVersion($objectVersion, $attributesMetadata, $stack);
+        }
+
         foreach ($stack as $attribute => $attributeValue) {
             $attributeContext = $this->getAttributeNormalizationContext($object, $attribute, $context);
 
@@ -320,7 +325,9 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         }
 
         $allowedAttributes = $this->getAllowedAttributes($type, $context, true);
+        $versionedConstraintAttributeCallables = $this->getVersionedConstraintAttributeCallables($type);
         $normalizedData = $this->prepareForDenormalization($data);
+
         $extraAttributes = [];
 
         $mappedClass = $this->getMappedClass($normalizedData, $type, $context);
@@ -336,6 +343,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             $normalizedData = $this->removeNestedValue($serializedPath->getElements(), $normalizedData);
         }
 
+        $objectVersion = $this->getObjectVersion($type, $normalizedData);
         $normalizedData = array_merge($normalizedData, $nestedData);
 
         $object = $this->instantiateObject($normalizedData, $mappedClass, $context, new \ReflectionClass($mappedClass), $allowedAttributes, $format);
@@ -382,6 +390,9 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             }
 
             $value = $this->applyCallbacks($value, $resolvedClass, $attribute, $format, $attributeContext);
+            if (null !== $objectVersion) {
+                $value = $this->getValueByVersion($value, $objectVersion, $attribute, $versionedConstraintAttributeCallables);
+            }
 
             try {
                 $this->setAttributeValue($object, $attribute, $value, $format, $attributeContext);
@@ -592,6 +603,21 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         }
 
         throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('The type of the "%s" attribute for class "%s" must be one of "%s" ("%s" given).', $attribute, $currentClass, implode('", "', array_keys($expectedTypes)), get_debug_type($data)), $data, array_keys($expectedTypes), $context['deserialization_path'] ?? $attribute);
+    }
+
+    private function getObjectVersion(object|string $objectOrClass, array $stack): ?string
+    {
+        $objectVersion = null;
+        foreach ($this->classMetadataFactory?->getMetadataFor($objectOrClass)->getAttributesMetadata() ?? [] as $attribute => $attributeMetadata) {
+            if ($attributeMetadata->isVersion()) {
+                if ($objectVersion !== null) {
+                    throw new LogicException(sprintf('Too many version ["%s","%s] attributes class "%s"', $attribute, $objectVersion, is_object($objectOrClass) ? get_class($objectOrClass) : $objectOrClass));
+                }
+                $objectVersion = $attribute;
+            }
+        }
+
+        return $objectVersion ? $stack[$objectVersion] : null;
     }
 
     /**
@@ -811,5 +837,44 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         }
 
         return $mappedClass;
+    }
+
+    /**
+     * @param array<string, AttributeMetadataInterface> $attributesMetadata
+     */
+    private function filterAttributesByVersion(string $objectVersion, array $attributesMetadata, array $stack): array
+    {
+        return array_filter(
+            $stack,
+            fn (string $key) => $this->isVersionCompatible($objectVersion, $attributesMetadata, $key),
+            \ARRAY_FILTER_USE_KEY
+        );
+    }
+
+    /**
+     * @param array<string, callable> $callables
+     */
+    private function getValueByVersion(mixed $value, string $objectVersion, string $attribute, array $callables): mixed
+    {
+        if (!isset($callables[$attribute])) {
+            return $value;
+        }
+
+        return $callables[$attribute]($objectVersion) ? $value : null;
+    }
+
+    /**
+     * @param class-string $class
+     *
+     * @return array<class-string, Closure(string)>
+     */
+    private function getVersionedConstraintAttributeCallables(string $class): array
+    {
+        $attributes = [];
+        foreach ($this->classMetadataFactory?->getMetadataFor($class)?->getAttributesMetadata() ?? [] as $attribute => $attributeMetadata) {
+            $attributes[$attribute] = $attributeMetadata->isVersionCompatible(...);
+        }
+
+        return $attributes;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Annotation/VersionConstraintTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/VersionConstraintTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Annotation;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
+use Symfony\Component\Serializer\Mapping\AttributeMetadata;
+
+/**
+ * @author Olivier Michaud <olivier@micoli.org>
+ */
+class VersionConstraintTest extends TestCase
+{
+    /**
+     * @dataProvider providesNormalizeVersionAndConstraints
+     */
+    public function testNormalizeVersionConstraint(bool $expectedResult, ?string $version, ?string $since, ?string $until)
+    {
+        $versionConstraint = new VersionConstraint(since: $since, until: $until);
+        $this->assertSame($expectedResult, $versionConstraint->isVersionCompatible($version));
+    }
+
+    public static function providesNormalizeVersionAndConstraints(): \Generator
+    {
+        yield 'Version in range' => [true, '1.2', '1.1', '1.5'];
+        yield 'Version below range with both limits' => [false, '0.9', '1.1', '1.5'];
+        yield 'Version below range only with lower limit' => [false, '0.9', '1.1', null];
+        yield 'Version in range only with upper limit' => [true, '0.9', null, '1.5'];
+        yield 'Version above range with both limits' => [false, '2.0', '1.1', '1.5'];
+        yield 'Version above range only with upper limit' => [false, '2.0', null, '1.5'];
+        yield 'Version in range only with low limit ' => [true, '2.0', '1.1', null];
+        yield 'Version in range due to no limits' => [true, '2.0', null, null];
+        yield 'No version and no limits' => [true, '', null, null];
+        yield 'No version to no limits' => [false, '', '1.1', '1.5'];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/DoubleVersionDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/DoubleVersionDummy.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
+
+use Symfony\Component\Serializer\Annotation\Version;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
+
+/**
+ * @author Olivier MICHAUD <olivier@micoli.org>
+ */
+class DoubleVersionDummy
+{
+    private $foo;
+
+    /**
+     * @Version
+     */
+    public string $objectVersion1;
+
+    /**
+     * @Version
+     */
+    public string $objectVersion2;
+
+    /**
+     * @VersionConstraint(
+     *     since="1.1",
+     *     until="1.5"
+     * )
+     */
+    public ?string $versionedProperty;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/VersionDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/VersionDummy.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
+
+use Symfony\Component\Serializer\Annotation\Version;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
+
+/**
+ * @author Olivier MICHAUD <olivier@micoli.org>
+ */
+class VersionDummy
+{
+    private $foo;
+
+    /**
+     * @Version
+     */
+    public string $objectVersion;
+
+    /**
+     * @VersionConstraint(
+     *     since="1.1",
+     *     until="1.5"
+     * )
+     */
+    public ?string $versionedProperty;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/DoubleVersionDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/DoubleVersionDummy.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Annotation\Version;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
+
+/**
+ * @author Olivier MICHAUD <olivier@micoli.org>
+ */
+class DoubleVersionDummy
+{
+    private $foo;
+
+    #[Version]
+    public string $objectVersion1;
+
+    #[Version]
+    public string $objectVersion2;
+
+    #[VersionConstraint(since: '1.1', until: '1.5')]
+    public ?string $versionedProperty;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/VersionDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/VersionDummy.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Annotation\Version;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
+
+/**
+ * @author Olivier MICHAUD <olivier@micoli.org>
+ */
+class VersionDummy
+{
+    private $foo;
+
+    #[Version]
+    public string $objectVersion;
+
+    #[VersionConstraint(since: '1.1', until: '1.5')]
+    public ?string $versionedProperty;
+}

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTestCase.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTestCase.php
@@ -135,6 +135,34 @@ abstract class AnnotationLoaderTestCase extends TestCase
         $this->assertTrue($attributesMetadata['ignored2']->isIgnored());
     }
 
+    public function testLoadVersionConstraint()
+    {
+        $classMetadata = new ClassMetadata($this->getNamespace() . '\VersionDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertTrue($attributesMetadata['versionedProperty']->isVersionCompatible('1.2'));
+        $this->assertFalse($attributesMetadata['versionedProperty']->isVersionCompatible('0.9'));
+        $this->assertFalse($attributesMetadata['versionedProperty']->isVersionCompatible('2.1'));
+    }
+
+    public function testLoadVersion()
+    {
+        $classMetadata = new ClassMetadata($this->getNamespace() . '\VersionDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertTrue($attributesMetadata['objectVersion']->isVersion());
+        $this->assertFalse($attributesMetadata['foo']->isVersion());
+    }
+
+    public function testLoadVersionWithError()
+    {
+        $this->expectExceptionMessageMatches('!DoubleVersionDummy::objectVersion2\(\)" cannot be added\. Version holder property can only be set once\.!');
+        $classMetadata = new ClassMetadata($this->getNamespace() . '\DoubleVersionDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+    }
+
     public function testLoadContexts()
     {
         $this->assertLoadedContexts($this->getNamespace().'\ContextDummy', $this->getNamespace().'\ContextDummyParent');

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Serializer\Tests\Normalizer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\Serializer\Annotation\VersionConstraint;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
@@ -27,6 +28,7 @@ use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractNormalizerDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Annotations\IgnoreDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Annotations\VersionDummy as AnnotationsVersionDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NullableConstructorArgumentDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NullableOptionalConstructorArgumentDummy;
@@ -265,5 +267,75 @@ class AbstractNormalizerTest extends TestCase
         $normalizer = new PropertyNormalizer($this->classMetadata);
 
         $this->assertSame([], $normalizer->normalize($dummy));
+    }
+
+    /**
+     * @dataProvider providesNormalizeVersionAndConstraints
+     */
+    public function testNormalizeVersionConstraint(?string $version, ?string $since, ?string $until, array $expectedVersionedProperties)
+    {
+        $classMetadata = new ClassMetadata(AnnotationsVersionDummy::class);
+
+        $attributeVersionMetadata = new AttributeMetadata('objectVersion');
+        $attributeVersionMetadata->setVersion(true);
+        $classMetadata->addAttributeMetadata($attributeVersionMetadata);
+
+        $attributeVersionConstraintMetadata = new AttributeMetadata('versionedProperty');
+        $attributeVersionConstraintMetadata->setVersionConstraint(new VersionConstraint(since: $since, until: $until));
+        $classMetadata->addAttributeMetadata($attributeVersionConstraintMetadata);
+
+        $this->classMetadata->method('getMetadataFor')->willReturn($classMetadata);
+
+        $dummy = new AnnotationsVersionDummy();
+        $dummy->objectVersion = $version;
+        $dummy->versionedProperty = 'foo';
+
+        $normalizer = new PropertyNormalizer($this->classMetadata);
+
+        $this->assertSame([
+                'foo' => null,
+                'objectVersion' => $version,
+            ] + $expectedVersionedProperties, $normalizer->normalize($dummy));
+    }
+
+    public static function providesNormalizeVersionAndConstraints(): \Generator
+    {
+        yield 'Version in range' => ['1.2', '1.1', '1.5', ['versionedProperty' => 'foo']];
+        yield 'Version out of range' => ['0.9', '1.1', '1.5', []];
+    }
+
+    /**
+     * @dataProvider providesDenormalizeVersionAndConstraints
+     */
+    public function testDenormalizeVersionConstraint(?string $version, ?string $since, ?string $until, array $normalizedVersionedProperties, ?string $expectedVersionedProperty)
+    {
+        $classMetadata = new ClassMetadata(AnnotationsVersionDummy::class);
+
+        $attributeVersionMetadata = new AttributeMetadata('objectVersion');
+        $attributeVersionMetadata->setVersion(true);
+        $classMetadata->addAttributeMetadata($attributeVersionMetadata);
+
+        $attributeVersionConstraintMetadata = new AttributeMetadata('versionedProperty');
+        $attributeVersionConstraintMetadata->setVersionConstraint(new VersionConstraint(since: $since, until: $until));
+        $classMetadata->addAttributeMetadata($attributeVersionConstraintMetadata);
+
+        $this->classMetadata->method('getMetadataFor')->willReturn($classMetadata);
+
+        $normalized = [
+            'foo' => null,
+            'objectVersion' => $version,
+            'versionedProperty' => 'foo',
+        ];
+
+        $normalizer = new PropertyNormalizer($this->classMetadata);
+
+        $denormalizedObject = $normalizer->denormalize($normalized, AnnotationsVersionDummy::class);
+        $this->assertSame($expectedVersionedProperty, $denormalizedObject->versionedProperty);
+    }
+
+    public static function providesDenormalizeVersionAndConstraints(): \Generator
+    {
+        yield 'Version in range' => ['1.2', '1.1', '1.5', ['versionedProperty' => 'foo'], 'foo'];
+        yield 'Version out of range' => ['0.9', '1.1', '1.5', [], null];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #30848
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

- Add `version` annotation/attribute to be set on the property holding the version of the normalized representation (only one property can be set as `Version`)
- Add `VersionConstraint` annotation/attribute. That attribute control restriction on normalisation/denormalization depending on the value of the property that hold `Version` attribute. Inner properties are `since` and `until`. At least one of them has to be set.
- Either `Version.version`, `VersionConstraint.since` and `VersionConstraint.until` are expressed as semver string, and must be compliant with [version_compare](https://www.php.net/manual/fr/function.version-compare.php) function. A property restricted by a constraint is defined as : `notDefined` < `since|null` <= `defined` <= `until|null` < `notDefined`

Behavior and naming are inspired by https://jmsyst.com/libs/serializer/master/reference/annotations#since and https://jmsyst.com/libs/serializer/master/reference/annotations#until

Logic is as follow:
 - Normalization
    A restricted property by a `VersionConstraint` is not added to the normalized representation if the constraint is not satisfied 
 - Denormalization
    A restricted property by a `VersionConstraint` is set to null if the constraint is not satisfied or to the value if the constraint is satisfied

Example of usage
```
class VersionAwareObject
{
    private $foo;

    /**
     * @Version
     */
    public string $version;

    /**
     * @VersionConstraint(
     *     since="1.1",
     *     until="1.5"
     * )
     */
    public ?string $name;

    /**
     * @VersionConstraint(
     *     since="1.6"
     * )
     */
    public ?string $lastName;
}
```

I don't see any Breaking Changes up to now
